### PR TITLE
Migrate to Spectre.Console.Cli

### DIFF
--- a/BuildCleaner/BuildCleaner.csproj
+++ b/BuildCleaner/BuildCleaner.csproj
@@ -19,8 +19,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageReference Include="Spectre.Cli.Extensions.DependencyInjection" Version="0.4.0" />
-    <PackageReference Include="Spectre.Console" Version="0.44.0" />
+    <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.1.0" />
+    <PackageReference Include="Spectre.Console" Version="0.45.0" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BuildCleaner/GlobalUsings.cs
+++ b/BuildCleaner/GlobalUsings.cs
@@ -21,6 +21,6 @@ global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Logging;
 global using Microsoft.Extensions.Options;
-global using Spectre.Cli.Extensions.DependencyInjection;
+global using Spectre.Console.Cli.Extensions.DependencyInjection;
 global using Spectre.Console;
 global using Spectre.Console.Cli;


### PR DESCRIPTION
Spectre.Console has removed CLI functions into its own Spectre.Console.Cli NuGet package, this PR addresses the changes needed to be able to adopt the latest Spectre.Console version.

* Update Spectre.Console to 0.45.0
* Add Spectre.Console.Cli 0.45.0
* Migrate from Spectre.Cli.Extensions.DependencyInjection to Spectre.Console.Cli.Extensions.DependencyInjection